### PR TITLE
Fix the "Getting started with React" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Put the compiled JS files into HTML.
 - [React (Virtual) DOM Terminology](http://facebook.github.io/react/docs/glossary.html), by Sebastian Markbåge
 - [The React Quick Start Guide](http://www.jackcallister.com/2015/01/05/the-react-quick-start-guide.html), by Jack Callister
 - [Learning React.js: Getting Started and Concepts](https://scotch.io/tutorials/learning-react-getting-started-and-concepts), by Ken Wheeler
-- [Getting started with React](http://ryanclark.me/getting-started-with-react/), by Ryan Clark
+- [Getting started with React](http://ryanclark.me/getting-started-with-react), by Ryan Clark
 - [React JS Tutorial and Guide to the Gotchas](https://zapier.com/engineering/react-js-tutorial-guide-gotchas/), by Justin Deal
 - [React Primer](https://github.com/BinaryMuse/react-primer), by Binary Muse
 - [jQuery versus React.js thinking](http://blog.zigomir.com/react.js/jquery/2015/01/11/jquery-versus-react-thinking.html), by zigomir


### PR DESCRIPTION
It appears that a trailing slash now produces HTTP error 404.