### PR TITLE
Use the let in code demos and some formatting in README's code examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Before v0.14, React use `JSTransform.js` to translate `<script type="text/jsx">`
 You could also use JavaScript in JSX. It takes angle brackets (&lt;) as the beginning of HTML syntax, and curly brackets (`{`) as the beginning of JavaScript syntax.
 
 ```js
-var names = ['Alice', 'Emily', 'Kate'];
+let names = ['Alice', 'Emily', 'Kate'];
 
 ReactDOM.render(
   <div>
   {
-    names.map(function (name) {
-      return <div>Hello, {name}!</div>
+    names.map(function (name, index) {
+      return <div key={index}>Hello, {name}!</div>
     })
   }
   </div>,
@@ -147,21 +147,26 @@ Please remember the first letter of the component's name must be capitalized, ot
 // wrong
 class HelloMessage extends React.Component {
   render() {
-    return <h1>
-      Hello {this.props.name}
-    </h1><p>
-      some text
-    </p>;
+    return (
+      <h1>
+        Hello {this.props.name}
+      </h1>
+      <p>
+        some text
+      </p>;
+    );
   }
 }
 
 // correct
 class HelloMessage extends React.Component {
   render() {
-    return <div>
+    return (
+    <div>
       <h1>Hello {this.props.name}</h1>
       <p>some text</p>
-    </div>;
+    </div>
+    );
   }
 }
 ```

--- a/demo02/index.html
+++ b/demo02/index.html
@@ -9,7 +9,7 @@
   <body>
     <div id="example"></div>
     <script type="text/babel">
-      var names = ['Alice', 'Emily', 'Kate'];
+      let names = ['Alice', 'Emily', 'Kate'];
 
       ReactDOM.render(
         <div>

--- a/demo03/index.html
+++ b/demo03/index.html
@@ -9,7 +9,7 @@
   <body>
     <div id="example"></div>
     <script type="text/babel">
-      var arr = [
+      let arr = [
         <h1 key="1">Hello world!</h1>,
         <h2 key="2">React is awesome</h2>,
       ];


### PR DESCRIPTION
Changes I made are about:

1. Use let instead of var in code demos.
2. Adhere code examples to code demos.
3. Some formatting in readme's code example Demo04 in order to make clear that a React component should only have one top child node.